### PR TITLE
Update dependency requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ to Gerrit instances that are using the [Gerrit verify-status plugin].
 
 # Reqiurements
  * Gerrit ver 2.13+
- * Jenkins ver 1.580.1+
- * Jenkins [Gerrit Trigger Plugin]
+ * Jenkins ver 1.625.3+
+ * Jenkins [Gerrit Trigger Plugin] ver 2.22.0+
 
 # Quick Start Guide
 This is a quick start guide on how to quickly install and configure Gerrit and
@@ -49,7 +49,7 @@ Settings -> HTTP Password -> Generate Password
 
 ## Install Jenkins verify-status-reporter plugin
   * Install the Jenkins Gerrit trigger plugin using the Jenkins plugin manager.
-  * Install this plugin plugin.
+  * Install this plugin.
   * Configure the Gerrit trigger global config to connect to the Gerrit instance.
 ```
 Jenkins -> Manage Jenkins -> Gerrit Trigger

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.580.1</version>
+        <version>2.7</version>
         <relativePath />
     </parent>
 
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>com.sonyericsson.hudson.plugins.gerrit</groupId>
             <artifactId>gerrit-trigger</artifactId>
-            <version>2.16.0</version>
+            <version>2.22.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
This plugin requires a version of the Gerrit Trigger plugin
that contains GERRIT_CHANGE_COMMIT_MESSAGE env variable[1].
Updating the version of Gerrit trigger also requires an update
to Jenkins to ver 1.625.3+

[1] https://github.com/jenkinsci/gerrit-trigger-plugin/commit/b522321757217e12718e8f073926720b55431f2e