### PR TITLE
Handle recheck use case

### DIFF
--- a/src/main/java/com/google/gerrit/extensions/api/changes/RevisionApi.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/RevisionApi.java
@@ -37,7 +37,7 @@ import java.util.Set;
 public interface RevisionApi {
   void delete() throws RestApiException;
   void review(ReviewInput in) throws RestApiException;
-  // for verify-status plugin
+  // for verify-status-reporter plugin
   VerifyStatusApi verifyStatus() throws RestApiException;
   
 
@@ -77,7 +77,7 @@ public interface RevisionApi {
       throw new NotImplementedException();
     }
 
-    // for verify-status plugin
+    // for verify-status-reporter plugin
     @Override
     public VerifyStatusApi verifyStatus() throws RestApiException {
       throw new NotImplementedException();

--- a/src/main/java/org/jenkinsci/plugins/verifystatus/VerificationsPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/verifystatus/VerificationsPublisher.java
@@ -186,10 +186,12 @@ public class VerificationsPublisher extends Publisher {
         data.abstain = true;
       }
       
-      // TODO: pass the special Gerrit "recheck" comment to this category
-      // Gerrit trigger does not support a GERRIT_COMMENT Env var yet.
-      // https://issues.jenkins-ci.org/browse/JENKINS-37633
-      data.category = "";
+      String replyComment = getEnvVar(build, listener, "GERRIT_EVENT_COMMENT_TEXT");
+      if (replyComment.contains("recheck")) {
+        data.category = "recheck";
+      } else {
+        data.category = "";
+      }
       String inCategory = getVerifyStatusCategory();
       if (!inCategory.isEmpty()) {
         data.category = inCategory;


### PR DESCRIPTION
The Gerrit verify-status plugin has a special category called
'recheck'[1].  Assign 'recheck' from the Gerrit reply comment to
the category so that verify-status knows that this is a test re-run.

[1] https://gerrit.googlesource.com/plugins/verify-status/+/master/src/main/resources/Documentation/rest-api-changes.md#VerifyInput