### PR TITLE
Update to use newer Gerrit Trigger Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ to Gerrit instances that are using the [Gerrit verify-status plugin].
 
 # Reqiurements
  * Gerrit ver 2.13+
- * Jenkins ver 1.580.1+
- * Jenkins [Gerrit Trigger Plugin]
+ * Jenkins ver 1.625.3+
+ * Jenkins [Gerrit Trigger Plugin] ver 2.20.0+
 
 # Quick Start Guide
 This is a quick start guide on how to quickly install and configure Gerrit and
@@ -49,8 +49,8 @@ Settings -> HTTP Password -> Generate Password
 
 ## Install Jenkins verify-status-reporter plugin
   * Install the Jenkins Gerrit trigger plugin using the Jenkins plugin manager.
-  * Install this plugin plugin.
-  * Configure the Gerrit trigger global config to connect to the Gerrit instance.
+  * Install this plugin.
+  * Configure the Gerrit trigger global config to connect to a Gerrit instance.
 ```
 Jenkins -> Manage Jenkins -> Gerrit Trigger
 ```
@@ -62,9 +62,10 @@ Enable Environment variables
 Save settings
 ```
   * Create a new Jenkins job
-  * Add a regular expression [Gerrit trigger event].  Make it trigger on 'recheck'.
-  * Configure the Gerrit project settings. 
-  * Add a 'Post a verification to Gerrit' [post-build action]. You can leave the [verification parameters] blank.
+  * Setup a Gerrit trigger event and set all of the paramters to [Human readable]
+  * Add a [regular expression trigger] event.  Make it trigger on 'recheck'.
+  * Configure the Gerrit project settings.
+  * Add a 'Post a verification to Gerrit' [post-build action].  You can leave the [verification parameters] blank.
   * Save the job.
 
 ## Testing
@@ -72,19 +73,20 @@ Save settings
   * View any patchset.
   * Reply to a patchset with a 'recheck' message (this should auotmatically kick off a jenkins build).
   * After Jenkins has completed running the build it will send a verification report to Gerrit.
-  * The report should now appear on the Gerrit UI (on replied to patchset).
+  * The report should now appear on the Gerrit UI (on the replied to patchset).
 
 ## Debugging
   * Check the Gerrit logs and Jenkins logs to see if there are any errors
-  * Communication between Gerrit and Jenkins are done using REST APIs so make sure the security is setup so that one server can communicate with the other.
+  * Communication between Gerrit and Jenkins are done using SSH and REST APIs so make sure the security is setup so that one server can communicate with the other.
 
 [Gerrit Trigger Plugin]: https://wiki.jenkins-ci.org/display/JENKINS/Gerrit+Trigger
 [Gerrit verify-status plugin]: https://gerrit.googlesource.com/plugins/verify-status/+/master/src/main/resources/Documentation/about.md
 [initialize the database]: https://gerrit.googlesource.com/plugins/verify-status/+/master/src/main/resources/Documentation/database.md
 [Configure access controls]: http://imgur.com/fs4jEJu
 [Gerrit Rest API]: http://imgur.com/hRo40Vo
-[Gerrit trigger event]: http://imgur.com/VaZTEO6
+[regular expression trigger]: http://imgur.com/VaZTEO6
 [post-build action]: http://imgur.com/EXMhHal
 [enable environment variables]: http://imgur.com/sDWN5J3
 [Configure access controls]: http://imgur.com/fs4jEJu
 [verification parameters]: http://imgur.com/u1iwCBm
+[Human readable]: https://imgur.com/a/h8B4z

--- a/pom.xml
+++ b/pom.xml
@@ -12,9 +12,10 @@
     <artifactId>verify-status-reporter</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
-
     <name>Verify Status Reporter Plugin</name>
+    <description>Post test reports to Gerrit</description>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/verify-status-reporter</url>
+
     <licenses>
         <license>
             <name>Apache License Version 2.0</name>
@@ -81,28 +82,17 @@
         <dependency>
             <groupId>com.sonyericsson.hudson.plugins.gerrit</groupId>
             <artifactId>gerrit-trigger</artifactId>
-            <version>2.16.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.2.2</version>
+            <version>2.22.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <version>19.0</version>
         </dependency>
         <dependency>
             <groupId>com.urswolfer.gerrit.client.rest</groupId>
             <artifactId>gerrit-rest-java-client</artifactId>
             <version>0.8.5</version>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.10</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Update to depend on Gerrit trigger ver 2.22.0 so we can get the
GERRIT_EVENT_COMMENT_TEXT[1] parameter.  This is how we communicate
to Gerrit that the published test result is from a re-run.

[1] https://github.com/jenkinsci/gerrit-trigger-plugin/commit/b522321757217e12718e8f073926720b55431f2e