### PR TITLE
Report test re-runs with 'rerun' field

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ Save settings
   * Setup a Gerrit trigger event and set all of the paramters to [Human readable]
   * Add a [regular expression trigger] event.  Make it trigger on 'recheck'.
   * Configure the Gerrit project settings.
-  * Add a 'Post a verification to Gerrit' [post-build action].  You can leave the [verification parameters] blank.
+  * Add a 'Post a verification to Gerrit' [post-build action].
+  * Set the Rerun Comment to 'recheck', you can leave the other [verification parameters] blank.
   * Save the job.
 
 ## Testing

--- a/src/main/java/com/google/gerrit/extensions/api/changes/VerificationInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/VerificationInfo.java
@@ -21,6 +21,7 @@ public class VerificationInfo {
   public String url;
   public Short value;
   public boolean abstain;
+  public boolean rerun;
   public String reporter;
   public String comment;
   public Timestamp granted;

--- a/src/main/resources/org/jenkinsci/plugins/verifystatus/VerificationsPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/verifystatus/VerificationsPublisher/config.jelly
@@ -30,6 +30,9 @@
         <f:entry title="${%jenkins.plugin.settings.verifystatus.category}" field="verifyStatusCategory">
             <f:textbox default=""/>
         </f:entry>
+        <f:entry title="${%jenkins.plugin.settings.verifystatus.rerun}" field="verifyStatusRerun">
+            <f:textbox default=""/>
+        </f:entry>
     </f:section>
 
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/verifystatus/VerificationsPublisher/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/verifystatus/VerificationsPublisher/config.properties
@@ -11,3 +11,4 @@ jenkins.plugin.settings.verifystatus.reporter=Reporter
 jenkins.plugin.settings.verifystatus.reporter.description=User that reported the report.
 jenkins.plugin.settings.verifystatus.category=Category
 jenkins.plugin.settings.verifystatus.category.description=Category for the report.
+jenkins.plugin.settings.verifystatus.rerun=Rerun Comment

--- a/src/main/resources/org/jenkinsci/plugins/verifystatus/VerificationsPublisher/help-verifystatusCategory.html
+++ b/src/main/resources/org/jenkinsci/plugins/verifystatus/VerificationsPublisher/help-verifystatusCategory.html
@@ -1,5 +1,3 @@
 <div>
-    The category for the test report.  A "recheck" is a special category
-    used to indicate a re-run a Gerrit patchset. View the Gerrit verify-status
-    plugin docs for more information.
+    The category for the test report.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/verifystatus/VerificationsPublisher/help-verifystatusRerun.html
+++ b/src/main/resources/org/jenkinsci/plugins/verifystatus/VerificationsPublisher/help-verifystatusRerun.html
@@ -1,0 +1,6 @@
+<div>
+    Gerrit comment to indicate that this job is a re-ran on the same patchset.
+    Typically this should match the Gerrit trigger to re-run test jobs.
+    For example "recheck" in the "Comment Added Contains Regular Expression"
+    Gerrit trigger.
+</div>


### PR DESCRIPTION
Gerrit verify-status plugin used to track test reruns by looking for
a special "recheck" message in the category field.  Now reruns are
tracked with a special rerun bit.  Decoupling the two provides for
a more flexible solution.  We can now report to Gerrit using the rerun
field instead of using the category field.